### PR TITLE
Removed all SVN-style __version__="$Revision$" logic in preparation for ...

### DIFF
--- a/examples/gcal.ty
+++ b/examples/gcal.ty
@@ -22,7 +22,6 @@ GCAL is described fully in:
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi

--- a/examples/hierarchical.ty
+++ b/examples/hierarchical.ty
@@ -7,7 +7,6 @@ be modified to do so in the future.
 
 $Id$
 """
-__version__='$Revision$'
 
 from math import pi
 

--- a/examples/saccade_demo.ty
+++ b/examples/saccade_demo.ty
@@ -12,7 +12,6 @@ Saccade Demo example.  This script defines three sheets:
 
 $Id$
 """
-__version__='$Revision$'
 
 import pdb
 

--- a/examples/som_retinotopy.ty
+++ b/examples/som_retinotopy.ty
@@ -16,7 +16,6 @@ the Visual Cortex, Springer.  Known differences include:
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import exp, sqrt

--- a/examples/tiny.ty
+++ b/examples/tiny.ty
@@ -3,7 +3,6 @@ Tiny example network useful for testing components.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi, sqrt

--- a/models/goodhill_network90.ty
+++ b/models/goodhill_network90.ty
@@ -9,7 +9,6 @@ NOT YET TESTED.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from numpy.oldnumeric import *

--- a/models/leaky_lissom_or.ty
+++ b/models/leaky_lissom_or.ty
@@ -5,7 +5,6 @@ Work in progress.
 
 $Id$
 """
-__version__='$Revision$'
 
 from math import pi, sqrt
 

--- a/models/lissom_fsa.ty
+++ b/models/lissom_fsa.ty
@@ -9,7 +9,6 @@ as the input patterns.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi, sqrt

--- a/models/lissom_oo_or.ty
+++ b/models/lissom_oo_or.ty
@@ -27,7 +27,6 @@ compared exhaustively to the original simulations.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi

--- a/models/lissom_or.ty
+++ b/models/lissom_or.ty
@@ -27,7 +27,6 @@ compared exhaustively to the original simulations.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi, sqrt

--- a/models/lissom_whisker_barrels.ty
+++ b/models/lissom_whisker_barrels.ty
@@ -15,7 +15,6 @@ $ ./topographica examples/lissom_whisker_barrels.ty
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import pi, sqrt

--- a/models/obermayer_pnas90.ty
+++ b/models/obermayer_pnas90.ty
@@ -16,7 +16,6 @@ Known differences from the reference simulation:
 
 $Id$
 """
-__version__='$Revision$'
 
 from math import sqrt, pi
 

--- a/models/sullivan_neurocomputing04.ty
+++ b/models/sullivan_neurocomputing04.ty
@@ -12,7 +12,6 @@ Input line thickness.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from math import exp,sqrt,fmod,pi,radians,sin,cos

--- a/topo/__init__.py
+++ b/topo/__init__.py
@@ -31,7 +31,6 @@ then show up in the GUI menus as potential input patterns.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 # The tests and the GUI are omitted from this list, and have to be
 # imported explicitly if desired.

--- a/topo/analysis/__init__.py
+++ b/topo/analysis/__init__.py
@@ -4,7 +4,6 @@ Analysis tools for Topographica, other than plotting tools.
 $Id$
 """
 
-__version__='$Revision$'
 
 # Automatically discover all .py files in this directory.
 import os,fnmatch

--- a/topo/analysis/featureresponses.py
+++ b/topo/analysis/featureresponses.py
@@ -6,7 +6,6 @@ on measuring responses while varying features of an input pattern.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import copy

--- a/topo/base/__init__.py
+++ b/topo/base/__init__.py
@@ -13,7 +13,6 @@ available in the Python path.
 
 $Id$
 """
-__version__='$Revision$'
 
 # For backwards compatibility; these files used to be in base/
 from imagen import boundingregion,sheetcoords,patterngenerator # pyflakes:ignore (API import)

--- a/topo/base/arrayutil.py
+++ b/topo/base/arrayutil.py
@@ -3,7 +3,6 @@ General utility functions and classes for Topographica that require numpy.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 import re
 

--- a/topo/base/cf.py
+++ b/topo/base/cf.py
@@ -19,7 +19,6 @@ CFProjection.
 $Id$
 """
 
-__version__ = '$Revision$'
 
 from copy import copy
 

--- a/topo/base/functionfamily.py
+++ b/topo/base/functionfamily.py
@@ -7,7 +7,6 @@ LearningFns: accept two 2d arrays and a scalar, return one of the arrays modifie
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBALERT: Documentation is just draft.
 

--- a/topo/base/projection.py
+++ b/topo/base/projection.py
@@ -3,7 +3,6 @@ Projection and related classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 import numpy
 from numpy import array,asarray,ones,sometrue, logical_and, logical_or

--- a/topo/base/sheet.py
+++ b/topo/base/sheet.py
@@ -19,7 +19,6 @@ simply by changing e.g. Sheet.nominal_density.
 $Id$
 """
 
-__version__ = '$Revision$'
 
 
 from numpy import zeros,array,arange,meshgrid

--- a/topo/base/sheetview.py
+++ b/topo/base/sheetview.py
@@ -11,7 +11,6 @@ originating source object.
 
 $Id$
 """
-__version__='$Revision$'
 
 import types
 import operator

--- a/topo/base/simulation.py
+++ b/topo/base/simulation.py
@@ -52,7 +52,6 @@ special dest_port.
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
 

--- a/topo/command/__init__.py
+++ b/topo/command/__init__.py
@@ -11,7 +11,6 @@ no matter what the context from which they are called.
 
 $Id$
 """
-__version__='$Revision$'
 
 import cPickle as pickle
 

--- a/topo/command/analysis.py
+++ b/topo/command/analysis.py
@@ -22,7 +22,6 @@ superclasses for the rest of the parameters and code.
 
 $Id$
 """
-__version__='$Revision$'
 
 import Image,ImageDraw
     

--- a/topo/command/pylabplot.py
+++ b/topo/command/pylabplot.py
@@ -13,7 +13,6 @@ different GUI or non-GUI uses.
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
     

--- a/topo/coordmapper/__init__.py
+++ b/topo/coordmapper/__init__.py
@@ -12,7 +12,6 @@ CoordinateMapperFn.
 
 $Id$
 """
-__version__='$Revision$'
 
 from math import atan,pi,atan2
 

--- a/topo/ep/__init__.py
+++ b/topo/ep/__init__.py
@@ -11,7 +11,6 @@ become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
 

--- a/topo/learningfn/__init__.py
+++ b/topo/learningfn/__init__.py
@@ -16,7 +16,6 @@ become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
 

--- a/topo/learningfn/optimized.py
+++ b/topo/learningfn/optimized.py
@@ -6,7 +6,6 @@ Requires the weave package; without it unoptimized versions are used.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 from numpy import zeros, ones
 

--- a/topo/learningfn/projfn.py
+++ b/topo/learningfn/projfn.py
@@ -8,7 +8,6 @@ ConnectionField objects.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 from numpy import ones,zeros
 import numpy.oldnumeric as Numeric

--- a/topo/learningfn/som.py
+++ b/topo/learningfn/som.py
@@ -3,7 +3,6 @@ SOM-based learning functions for CFProjections.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 
 from math import ceil

--- a/topo/misc/__init__.py
+++ b/topo/misc/__init__.py
@@ -11,5 +11,4 @@ $Id$
 # For backwards compatibility; this file used to be in misc/
 from imagen import patternfn # pyflakes:ignore (API import)
 
-__version__='$Revision$'
 

--- a/topo/misc/commandline.py
+++ b/topo/misc/commandline.py
@@ -6,7 +6,6 @@ Topographica files within a separate Python.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 from optparse import OptionParser

--- a/topo/misc/distribution.py
+++ b/topo/misc/distribution.py
@@ -3,7 +3,6 @@ Distribution class
 
 $Id$
 """
-__version__='$Revision$'
 # To do:
 #
 # - wrap bins for cyclic histograms

--- a/topo/misc/gendocs.py
+++ b/topo/misc/gendocs.py
@@ -25,7 +25,6 @@ From the Makefile (Tabs have been stripped)::
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import pydoc, glob, os

--- a/topo/misc/genexamples.py
+++ b/topo/misc/genexamples.py
@@ -18,7 +18,6 @@ for groups of targets, add to the group_targets dictionary.
 $Id$
 """
 
-__version__='$Revision$'
 
 # JABALERT: Should be cut down and simplified; most of what it does is
 # for historical rather than functional reasons.  E.g. the quick

--- a/topo/misc/keyedlist.py
+++ b/topo/misc/keyedlist.py
@@ -3,7 +3,6 @@ KeyedList sorted dictionary class.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 # CEBALERT: Do most uses of KeyedList look like they would be better

--- a/topo/misc/playerrobot.py
+++ b/topo/misc/playerrobot.py
@@ -9,7 +9,6 @@ This is a temporary home for this file until it finds a permanent home
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import time,array

--- a/topo/misc/ptz.py
+++ b/topo/misc/ptz.py
@@ -8,7 +8,6 @@ This class was tested with uvcdynctrl and Ubuntu 10.04 LTS.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 
 

--- a/topo/misc/robotics.py
+++ b/topo/misc/robotics.py
@@ -13,7 +13,6 @@ high-level communications with Player robots.
 
 $Id$
 """
-__version__ = '$Revision$'
 
 
 import Image,ImageOps

--- a/topo/misc/trace.py
+++ b/topo/misc/trace.py
@@ -9,7 +9,6 @@ aligned axes.
 
 $Id$
 """
-__version__ = '$Revision$'
 
 import os
 import bisect

--- a/topo/misc/unitsupport.py
+++ b/topo/misc/unitsupport.py
@@ -5,7 +5,6 @@ packages to interact with Topographica.
 $Id$
 """
 
-__version__ = "$Revision$"
 
 import param
 from param.parameterized import bothmethod

--- a/topo/misc/util.py
+++ b/topo/misc/util.py
@@ -3,7 +3,6 @@ General utility functions and classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 import re
 import random

--- a/topo/plotting/__init__.py
+++ b/topo/plotting/__init__.py
@@ -18,5 +18,4 @@ For more information, see the various modules in this package.
 
 $Id$
 """
-__version__='$Revision$'
 __all__ = ['bitmap','plot','plotgroup','plotfilesaver']

--- a/topo/plotting/bitmap.py
+++ b/topo/plotting/bitmap.py
@@ -19,7 +19,6 @@ The encapsulated PIL Image is accessible through the .bitmap attribute.
 
 $Id$
 """
-__version__='$Revision$'
 
 import os
 import Image

--- a/topo/plotting/plot.py
+++ b/topo/plotting/plot.py
@@ -3,7 +3,6 @@ Plot class.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import copy

--- a/topo/plotting/plotfilesaver.py
+++ b/topo/plotting/plotfilesaver.py
@@ -6,7 +6,6 @@ objects can also be instantiated explicitly, to save a series of plots.
 
 $Id$
 """
-__version__='$Revision$'
 
 import Image
 import numpy

--- a/topo/plotting/plotgroup.py
+++ b/topo/plotting/plotgroup.py
@@ -7,7 +7,6 @@ database, plus weight plots for one unit, and projections.
 
 $Id$
 """
-__version__='$Revision$'
 
 import copy
 import Image

--- a/topo/projection/__init__.py
+++ b/topo/projection/__init__.py
@@ -9,7 +9,6 @@ become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 from copy import copy
 

--- a/topo/projection/optimized.py
+++ b/topo/projection/optimized.py
@@ -3,4 +3,3 @@ Optimized versions of Projection classes.
 
 $Id$
 """
-__version__='$Revision$'

--- a/topo/responsefn/__init__.py
+++ b/topo/responsefn/__init__.py
@@ -17,7 +17,6 @@ become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 from topo.base.functionfamily import ResponseFn
 

--- a/topo/responsefn/optimized.py
+++ b/topo/responsefn/optimized.py
@@ -6,7 +6,6 @@ Requires the weave package; without it unoptimized versions are used.
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
 

--- a/topo/responsefn/optimized_cy.pyx
+++ b/topo/responsefn/optimized_cy.pyx
@@ -11,7 +11,6 @@ SVN for additional versions.
 
 $Id$
 """
-__version__='$Revision$'
 
 # Current weave vs cython timings (lissom_or, no scheduled events)
 

--- a/topo/responsefn/projfn.py
+++ b/topo/responsefn/projfn.py
@@ -6,7 +6,6 @@ when given an input pattern and a set of ConnectionField objects.
 
 $Id$
 """
-__version__='$Revision$'
 
 from numpy import sum,exp,zeros,ravel
 from numpy.oldnumeric import Float

--- a/topo/sheet/__init__.py
+++ b/topo/sheet/__init__.py
@@ -8,7 +8,6 @@ automatically become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 # Imported here so that all Sheets will be in the same package
 from topo.base.sheet import Sheet

--- a/topo/sheet/composer.py
+++ b/topo/sheet/composer.py
@@ -5,7 +5,6 @@ a sheet class, but can also be useful.
 
 $Id$
 """
-__version__='$Revision$'
 
 from numpy.oldnumeric import zeros
 

--- a/topo/sheet/lissom.py
+++ b/topo/sheet/lissom.py
@@ -3,7 +3,6 @@ LISSOM and related sheet classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 from numpy import zeros,ones
 import copy

--- a/topo/sheet/optimized.py
+++ b/topo/sheet/optimized.py
@@ -3,7 +3,6 @@ Inline-optimized Sheet classes
 
 $Id$
 """
-__version__='$Revision$'
 
 import param
 

--- a/topo/sheet/ptztracker.py
+++ b/topo/sheet/ptztracker.py
@@ -5,7 +5,6 @@ This class also gives instructions to move the camera.
 
 $Id$
 """
-__version__ = "$Revision$"
 
 
 

--- a/topo/sheet/saccade.py
+++ b/topo/sheet/saccade.py
@@ -19,7 +19,6 @@ controlling a ShiftingGeneratorSheet.
 
 $Id$
 """
-__version__ = '$Revision$'
 
 from numpy import sin,cos,pi,array,asarray,argmax,zeros,\
      nonzero,take,random

--- a/topo/sheet/slissom.py
+++ b/topo/sheet/slissom.py
@@ -3,7 +3,6 @@ The SLISSOM class.
 
 $Id$
 """
-__version__='$Revision$'
 
 from math import exp
 

--- a/topo/tests/__init__.py
+++ b/topo/tests/__init__.py
@@ -115,7 +115,6 @@ doctest
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBALERT: It might be good if tests/ were a directory at the top
 # level, with a subdirectory structure mirroring that of topo/. Then

--- a/topo/tests/functionaltest.py
+++ b/topo/tests/functionaltest.py
@@ -3,7 +3,6 @@ Simple framework to run a set of tests and report the results.
 
 $Id$
 """
-__version__='$Revision$'
 
 import traceback,sys,inspect
 

--- a/topo/tests/gui_tests.py
+++ b/topo/tests/gui_tests.py
@@ -3,7 +3,6 @@ Functional GUI tests: run_basic() and run_detailed().
 
 $Id$
 """
-__version__='$Revision$'
 
 import copy
 

--- a/topo/tests/reference/__init__.py
+++ b/topo/tests/reference/__init__.py
@@ -3,5 +3,4 @@ Files relating to matching Topographica's results and C++ LISSOM's.
 
 $Id$
 """
-__version__='$Revision$'
 

--- a/topo/tests/reference/lissom_fsa_reference.ty
+++ b/topo/tests/reference/lissom_fsa_reference.ty
@@ -4,7 +4,6 @@ LISSOM simulation designed to match C++ LISSOM's FSA simulation.
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBERRORALERT: need to remove DynamicNumber
 

--- a/topo/tests/reference/lissom_log_parser.py
+++ b/topo/tests/reference/lissom_log_parser.py
@@ -8,7 +8,6 @@ give the base filename path of the C++ LISSOM files, e.g.
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBHACKALERT: filename should change
 

--- a/topo/tests/reference/lissom_oo_or_reference.ty
+++ b/topo/tests/reference/lissom_oo_or_reference.ty
@@ -8,7 +8,6 @@ Please see the comments for lissom_or_reference.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 # CB: the plan is to make this file more and more general while

--- a/topo/tests/reference/lissom_or_reference.ty
+++ b/topo/tests/reference/lissom_or_reference.ty
@@ -51,7 +51,6 @@ All but the first two of these need to be fixed eventually.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 

--- a/topo/tests/test_script.py
+++ b/topo/tests/test_script.py
@@ -6,7 +6,6 @@ Buildbot shows how to run all these tests.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import pickle, copy, __main__, timeit, os, os.path, socket, cPickle, inspect, traceback, tempfile, shutil

--- a/topo/tests/testaudio.py
+++ b/topo/tests/testaudio.py
@@ -2,7 +2,6 @@
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBALERT: incomplete!
 

--- a/topo/tests/testbitmap.py
+++ b/topo/tests/testbitmap.py
@@ -11,7 +11,6 @@ classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 import topo
 from topo.plotting.bitmap import *

--- a/topo/tests/testboundingregion.py
+++ b/topo/tests/testboundingregion.py
@@ -3,7 +3,6 @@ Test cases for the boundingregion module.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import topo

--- a/topo/tests/testcfsom.py
+++ b/topo/tests/testcfsom.py
@@ -4,7 +4,6 @@ the PlotEngine system from a simulation.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import random

--- a/topo/tests/testdistribution.py
+++ b/topo/tests/testdistribution.py
@@ -3,7 +3,6 @@ Tests of distribution.py
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBALERT: almost finished. Clean up redundant tests, comment,
 # and test selectivity for non-cyclic quantities once that has been

--- a/topo/tests/testdummy.py
+++ b/topo/tests/testdummy.py
@@ -4,7 +4,6 @@ $Id$
 
 ### JCALERT: Does this file is of any interrest now?
 
-__version__='$Revision$'
 
 import unittest
 

--- a/topo/tests/testfeaturemap.py
+++ b/topo/tests/testfeaturemap.py
@@ -4,7 +4,6 @@ TestFeatureMap
 $Id$
 
 """
-__version__='$Revision$'
 
 
 

--- a/topo/tests/testimage.py
+++ b/topo/tests/testimage.py
@@ -2,7 +2,6 @@
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBALERT: incomplete - being written.
 

--- a/topo/tests/testmatplotlib.py
+++ b/topo/tests/testmatplotlib.py
@@ -1,7 +1,6 @@
 """
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 

--- a/topo/tests/testmatplotlib_tk.py
+++ b/topo/tests/testmatplotlib_tk.py
@@ -2,7 +2,6 @@
 Unit test for the matplot lib in tkgui
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import matplotlib

--- a/topo/tests/testnumbergen.py
+++ b/topo/tests/testnumbergen.py
@@ -3,7 +3,6 @@ Test cases for the numbergen module.
 
 $Id$
 """
-__version__ = '$Revision$'
 
 import unittest
 from topo import numbergen

--- a/topo/tests/testoutputfnsbasic.py
+++ b/topo/tests/testoutputfnsbasic.py
@@ -4,7 +4,6 @@ TestFeatureMap
 $Id$
 
 """
-__version__='$Revision$'
 
 
 # To do:

--- a/topo/tests/testoutputfnsoptimized.py
+++ b/topo/tests/testoutputfnsoptimized.py
@@ -2,7 +2,6 @@
 
 $Id$
 """
-__version__='$Revision$'
 
 # CEBHACKALERT: we should delete this file, right?
 

--- a/topo/tests/testparameterizedobject.py
+++ b/topo/tests/testparameterizedobject.py
@@ -4,7 +4,6 @@ Unit test for Parameterized.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 

--- a/topo/tests/testparameterizedobject_tk.py
+++ b/topo/tests/testparameterizedobject_tk.py
@@ -3,7 +3,6 @@ Tests for the tkParameterized classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 ## CB: add test for change of po

--- a/topo/tests/testparametersframe_tk.py
+++ b/topo/tests/testparametersframe_tk.py
@@ -3,7 +3,6 @@ Tests for the ParametersFrame classes.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import __main__

--- a/topo/tests/testpatterngenerator.py
+++ b/topo/tests/testpatterngenerator.py
@@ -4,7 +4,6 @@ basic patterns.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 

--- a/topo/tests/testplot.py
+++ b/topo/tests/testplot.py
@@ -3,7 +3,6 @@ Test for the Plot class.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import unittest

--- a/topo/tests/testplotfilesaver.py
+++ b/topo/tests/testplotfilesaver.py
@@ -3,7 +3,6 @@ Tests for the PlotFileSaver classes. Also tests analysis commands.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import os

--- a/topo/tests/testplotgroup.py
+++ b/topo/tests/testplotgroup.py
@@ -2,7 +2,6 @@
 Test for the PlotGroup class
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import topo.base.simulation

--- a/topo/tests/testsheet.py
+++ b/topo/tests/testsheet.py
@@ -3,7 +3,6 @@ Unit tests for sheet and sheetcoords.
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 from numpy import array

--- a/topo/tests/testsheetview.py
+++ b/topo/tests/testsheetview.py
@@ -2,7 +2,6 @@
 Unit test for SheetView
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 

--- a/topo/tests/testsimulation.py
+++ b/topo/tests/testsimulation.py
@@ -2,7 +2,6 @@
 Unit test for Simulation
 $Id$
 """
-__version__='$Revision$'
 
 import unittest
 import copy

--- a/topo/tests/testsnapshots.py
+++ b/topo/tests/testsnapshots.py
@@ -2,7 +2,6 @@
 
 $Id$
 """
-__version__='$Revision$'
 
 import unittest, copy, shutil, tempfile
 from numpy.testing import assert_array_equal

--- a/topo/tkgui/__init__.py
+++ b/topo/tkgui/__init__.py
@@ -8,7 +8,6 @@ GUIs or other types of interfaces can also be used.
 
 $Id$
 """
-__version__='$Revision$'
 
 import sys
 import os

--- a/topo/tkgui/featurecurvepanel.py
+++ b/topo/tkgui/featurecurvepanel.py
@@ -6,7 +6,6 @@ which are currently displayed separately from the gui.
 
 $Id$
 """
-__version__='$Revision$'
 
 import topo
 

--- a/topo/tkgui/plotgrouppanel.py
+++ b/topo/tkgui/plotgrouppanel.py
@@ -4,7 +4,6 @@ to be displayed.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import copy

--- a/topo/tkgui/projectionpanel.py
+++ b/topo/tkgui/projectionpanel.py
@@ -3,7 +3,6 @@ PlotgroupPanels for displaying ProjectionSheet plotgroups.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import ImageTk

--- a/topo/tkgui/templateplotgrouppanel.py
+++ b/topo/tkgui/templateplotgrouppanel.py
@@ -4,7 +4,6 @@ Panel for displaying preference maps and activity plot groups.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 import copy

--- a/topo/tkgui/testpattern.py
+++ b/topo/tkgui/testpattern.py
@@ -3,7 +3,6 @@ The Test Pattern window allows input patterns to be previewed.
 
 $Id$
 """
-__version__='$Revision$'
 
 ## Notes:
 # * need to remove audigen pgs

--- a/topo/tkgui/topoconsole.py
+++ b/topo/tkgui/topoconsole.py
@@ -4,7 +4,6 @@ TopoConsole class file.
 
 $Id$
 """
-__version__='$Revision$'
 
 
 # CB: does the status bar need to keep saying 'ok'? Sometimes

--- a/topo/transferfn/__init__.py
+++ b/topo/transferfn/__init__.py
@@ -16,7 +16,6 @@ become available for any model.
 
 $Id$
 """
-__version__='$Revision$'
 
 import copy
 

--- a/topo/transferfn/projfn.py
+++ b/topo/transferfn/projfn.py
@@ -5,7 +5,6 @@ CFs and applying an output function to each set of weights in turn.
 
 $Id$
 """
-__version__='$Revision$'
 
 from topo.base.cf import CFPOutputFn
 


### PR DESCRIPTION
...the

new git-based versioning; files that store a specific __version__ (not just
"$Revision$"), or actually do anything with __version__, or are external
files get to keep their __version__ property (FOR NOW!).
