### PR TITLE
version: Fixed the CalledProcessError problem

### DIFF
--- a/topographica
+++ b/topographica
@@ -22,7 +22,7 @@ if len(argv) > 1 and argv[1] == 'make-release-file':
         git_process = Popen(["git", "describe"], stdout=PIPE)
         git = git_process.communicate()[0].strip()
         if git_process.poll():
-            raise CalledProcessError
+            raise OSError
     except OSError, CalledProcessError:
         print "Could not run `git describe`, failed to create the release file"
         raise


### PR DESCRIPTION
This was due to CalledProcessError not being a built-in error, causing
`raise CalledProcessError` to think the error to be raised was in a
variable called `CalledProcessError`. In some other cases this was due to the constructor of `CalledProcessError` requiring parameters. This commit fixes both.

I could not reproduce this issue on either Python 2.6.8 nor 2.7.3, but I
did reproduce it on 2.6.6 and there are reports of people encountering this
on "some" version of 2.7.
