### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/vancegroup-mirrors/eigen.git
 [submodule "external/featuremapper"]
 	path = external/featuremapper
-	url = git@github.com:ioam/featuremapper.git
+	url = https://github.com/ioam/featuremapper.git


### PR DESCRIPTION
Change from ssh:// to https:// access scheme for `featuremapper`, so that those with no push access to `ioam` could check it out; supposed to fix Jenkins builds #229 / #230.
