### PR TITLE
Prevent 'docs' builder from starting unless there is a change in doc/.

### DIFF
--- a/topo/tests/buildbot/master.cfg
+++ b/topo/tests/buildbot/master.cfg
@@ -247,6 +247,17 @@ c['schedulers'].append(Nightly(name="Win7-nightly", builderNames=["Win7_32_allte
 c['schedulers'].append(ForceScheduler(name="force", builderNames=ALL_BUILDERS))
 
 from buildbot.schedulers.filter import ChangeFilter
+
+
+# CB: (I guess imports are scattered around because this file is in sections?)
+import re
+def _doc_change(change):
+    # detect if change included something in doc/
+    for file_ in change.files:
+        if re.match('doc/'):
+            return True
+    return False
+
 # Hook to rebuild docs
 c['schedulers'].append(Scheduler(
 	name="docs-hook",
@@ -256,5 +267,6 @@ c['schedulers'].append(Scheduler(
 	change_filter=ChangeFilter(
 		repository="https://github.com/ioam/topographica",
 		branch="master"
-	)
+	),
+        fileIsImportant = _doc_change
 ))


### PR DESCRIPTION
We only want to see new generated documentation immediately for changes to doc/; for changes elsewhere, we can wait a few days.

Note: completely untested! Test with the buildbot check config tool?

More detail: the docs builder is currently scheduled to build every commit via a GitHub post-receive hook, but also to build every three days. For the 'every commit' scheduler, this change should cause builds to start only if there is a change in doc/.
