### PR TITLE
Lissom color fixes for Blue-RedGreen LGN sheets

### DIFF
--- a/models/lissom.ty
+++ b/models/lissom.ty
@@ -433,7 +433,7 @@ for e in eyes:
                         e+cone+'Retina'+n, e+'Blue-RedGreen'+' LGN'+l+n,
                         name='AfferentCenter'+cone,
                         delay=0.05,connection_type=projection.SharedWeightCFProjection,
-                        strength=4.7*(-1)**(1+center_polarities.index(l))/2,
+                        strength=strength_scale*(-1)**(1+center_polarities.index(l))/2,
                         nominal_bounds_template=sheet.BoundingBox(radius=lgnaff_radius),
                         weights_generator=centerg)
 
@@ -442,7 +442,7 @@ for e in eyes:
                     e+'Blue'+'Retina'+n, e+'Blue-RedGreen'+' LGN'+l+n,
                     name='AfferentCenter'+'Blue',
                     delay=0.05,connection_type=projection.SharedWeightCFProjection,
-                    strength=4.7*(-1)**center_polarities.index(l),
+                    strength=strength_scale*(-1)**center_polarities.index(l),
                     nominal_bounds_template=sheet.BoundingBox(radius=lgnaff_radius),
                     weights_generator=centerg)
 


### PR DESCRIPTION
This pull request consists of ~~two~~ small bugfixes related to the Blue-RedGreen LGN sheets in lissom.ty.
1: So far a fixed value of 4.7 was used as strength from the retina sheets to the Blue-RedGreen LGN sheets. However, this value is only suitable for natural image datasets, and only if speed=0. Instead, strength_scale should be used which depends on
- Whether it is a natural image dataset or Gaussian input
- How fast patterns are moving

~~2: The red and green retina sheets were connected to the Blue-RedGreen LGN sheets using center weights. Instead, they should be connected using surround weights. Only the blue retina sheets should use center weights (as they do correctly). This is a bug in lissom_oo_or_cr.ty as well as lissom.ty~~
