### PR TITLE
Simplified submodel decorators by using method names

### DIFF
--- a/topo/submodels/gcal.py
+++ b/topo/submodels/gcal.py
@@ -81,23 +81,6 @@ class ModelGCAL(ColorEarlyVisionModel):
             nominal_bounds=sheet.BoundingBox(radius=self.area/2.0))
 
 
-    @Model.matchconditions('V1')
-    def V1_matchconditions(self, properties):
-        """
-        V1 connects to all LGN sheets.
-
-        Furthermore, it connects to itself with two projections:
-            * one lateral connection which is excitatory (short-range)
-            * one lateral connection which is inhibitory (long-range)
-        """
-        # TODO: Combine Afferent V1 On and Afferent V1 Off
-        # As soon as time_dependent=True for weights
-        return {'AfferentV1OnMatch': {'level': 'LGN', 'polarity': 'On'},
-                'AfferentV1OffMatch':{'level': 'LGN', 'polarity': 'Off'},
-                'LateralV1ExcitatoryMatch': {'level': 'V1'},
-                'LateralV1InhibitoryMatch': {'level': 'V1'}}
-
-
     def V1_afferent_projections(self, proj):
         sf_channel = proj.src.properties['SF'] if 'SF' in proj.src.properties else 1
         # Adjust delays so same measurement protocol can be used with and without gain control.
@@ -122,13 +105,30 @@ class ModelGCAL(ColorEarlyVisionModel):
                                             self.v1aff_radius*self.sf_spacing**(sf_channel-1)))
                 for lag in self.lags]
 
+
+    @Model.matchconditions('V1')
+    def AfferentV1OnMatch(self, properties):
+        return {'level': 'LGN', 'polarity': 'On'}
+
+
     @Model.cfprojection
     def AfferentV1OnMatch(self, proj):
         return self.V1_afferent_projections(proj)
 
+
+    @Model.matchconditions('V1')
+    def AfferentV1OffMatch(self, properties):
+        return {'level': 'LGN', 'polarity': 'Off'}
+
+
     @Model.cfprojection
     def AfferentV1OffMatch(self, proj):
         return self.V1_afferent_projections(proj)
+
+
+    @Model.matchconditions('V1')
+    def LateralV1ExcitatoryMatch(self, properties):
+        return {'level': 'V1'}
 
 
     @Model.cfprojection
@@ -140,6 +140,11 @@ class ModelGCAL(ColorEarlyVisionModel):
             strength=self.exc_strength,
             learning_rate=self.exc_lr,
             nominal_bounds_template=sheet.BoundingBox(radius=self.latexc_radius))
+
+
+    @Model.matchconditions('V1')
+    def LateralV1InhibitoryMatch(self, properties):
+        return {'level': 'V1'}
 
 
     @Model.cfprojection


### PR DESCRIPTION
This is my proposed simplification to the new submodel machinery. Now, only the `matchconditions` decorator requires and argument making the remaining decorators simpler to use.

For now, I have preserved all the original names, partially to help show how things have changes and partially because I do not know what conventions we wish to follow. Suggestions welcome!

EDIT: There are still the annoying param warnings about 'Setting non-Parameter attributes' to fix...
