### PR TITLE
Simplified self.message statements for sheets and projections

### DIFF
--- a/topo/submodels/__init__.py
+++ b/topo/submodels/__init__.py
@@ -575,20 +575,16 @@ class Model(param.Parameterized):
             instantiate_options=available_instantiate_options
 
         if 'sheets' in instantiate_options:
-            self.message('Sheets:\n')
             for sheet_spec in self.sheets.path_items.itervalues():
-                self.message(sheet_spec)
+                self.message('Level ' + sheet_spec.level + ': Sheet ' + str(sheet_spec))
                 sheet_spec()
-            self.message('\n\n')
 
         if 'projections' in instantiate_options:
-            self.message('Connections:\n')
             # No need to call _ordered_projections if time-dependent
             projections = self.projections.path_items.itervalues()
             for proj in self._order_projections(projections):
-                self.message('Connect ' + str(proj.src) + ' with ' + str(proj.dest) + \
-                             ' (Match name: ' + proj.matchname + \
-                             ', connection name: ' + str(proj.parameters['name']) + ')')
+                self.message('Match: ' + proj.matchname + ': Connection ' + str(proj.src) + \
+                             '->' + str(proj.dest) + ' ' + proj.parameters['name'])
                 proj()
 
 


### PR DESCRIPTION
Hi,

this is a small PR which changes the message statements.
Previously:
INFO:root:Time: 000000.00 ModelGCAL: Sheets:

INFO:root:Time: 000000.00 ModelGCAL: V1
INFO:root:Time: 000000.00 ModelGCAL: Retina
INFO:root:Time: 000000.00 ModelGCAL: LGNOn
INFO:root:Time: 000000.00 ModelGCAL: LGNOff
INFO:root:Time: 000000.00 ModelGCAL: 

INFO:root:Time: 000000.00 ModelGCAL: Connections:

INFO:root:Time: 000000.00 ModelGCAL: Connect Retina with LGNOn (Match name: afferent_projections, connection name: Afferent)
INFO:root:Time: 000000.00 ModelGCAL: Connect Retina with LGNOff (Match name: afferent_projections, connection name: Afferent)
INFO:root:Time: 000000.00 ModelGCAL: Connect LGNOn with LGNOn (Match name: lateral_gain_control_projections, connection name: LateralGC)
INFO:root:Time: 000000.00 ModelGCAL: Connect LGNOff with LGNOff (Match name: lateral_gain_control_projections, connection name: LateralGC)
INFO:root:Time: 000000.00 ModelGCAL: Connect LGNOn with V1 (Match name: afferent_ON_projections, connection name: LGNOnAfferent)
INFO:root:Time: 000000.00 ModelGCAL: Connect LGNOff with V1 (Match name: afferent_OFF_projections, connection name: LGNOffAfferent)
INFO:root:Time: 000000.00 ModelGCAL: Connect V1 with V1 (Match name: lateral_excitatory_projections, connection name: LateralExcitatory)
INFO:root:Time: 000000.00 ModelGCAL: Connect V1 with V1 (Match name: lateral_inhibitory_projections, connection name: LateralInhibitory)

Now:
INFO:root:Time: 000000.00 ModelGCAL: Level V1: Sheet V1
INFO:root:Time: 000000.00 ModelGCAL: Level Retina: Sheet Retina
INFO:root:Time: 000000.00 ModelGCAL: Level LGN: Sheet LGNOn
INFO:root:Time: 000000.00 ModelGCAL: Level LGN: Sheet LGNOff
INFO:root:Time: 000000.00 ModelGCAL: Match afferent_projections: Connection Retina->LGNOn Afferent
INFO:root:Time: 000000.00 ModelGCAL: Match afferent_projections: Connection Retina->LGNOff Afferent
INFO:root:Time: 000000.00 ModelGCAL: Match lateral_gain_control_projections: Connection LGNOn->LGNOn LateralGC
INFO:root:Time: 000000.00 ModelGCAL: Match lateral_gain_control_projections: Connection LGNOff->LGNOff LateralGC
INFO:root:Time: 000000.00 ModelGCAL: Match afferent_ON_projections: Connection LGNOn->V1 LGNOnAfferent
INFO:root:Time: 000000.00 ModelGCAL: Match afferent_OFF_projections: Connection LGNOff->V1 LGNOffAfferent
INFO:root:Time: 000000.00 ModelGCAL: Match lateral_excitatory_projections: Connection V1->V1 LateralExcitatory
INFO:root:Time: 000000.00 ModelGCAL: Match lateral_inhibitory_projections: Connection V1->V1 LateralInhibitory

Shorter & more precise.
