### PR TITLE
Updated Simulation to support class-based models

### DIFF
--- a/examples/gcal_usingsubmodel.ty
+++ b/examples/gcal_usingsubmodel.ty
@@ -1,3 +1,2 @@
 from topo.submodels.gcal import ModelGCAL
-gcal = ModelGCAL() # if needed, specify setup_options
-gcal() # if needed, specify instantiate_options
+topo.sim.model = ModelGCAL() # if needed, specify setup_options


### PR DESCRIPTION
Here are my proposed changes for how Topographica should interact with the new class-based models.

I decided against automatically loading the model when Topographica is run from the command-line. This would be very easy to implement by adding the following to the end of the `topographica` script:

``` python
if topo.sim.model: topo.sim()
```

The issue with this is that it gives the modeler no opportunity to tweak the model before loading it in the interactive Topographica environment (i.e. at the Topographica's IPython prompt). This would negate one of the big advantages of the new system - tweaking models without needing to load large components into memory.

If the user forgets to call `topo.sim` after setting `topo.sim.model`, the model will be automatically loading as soon as `topo.sim.run()` is invoked.
