### PR TITLE
Refactored submodel system to use ModelSpecs

### DIFF
--- a/topo/submodel/__init__.py
+++ b/topo/submodel/__init__.py
@@ -12,13 +12,13 @@ parameters for projections.
 import itertools
 
 from functools import wraps
-from collections import OrderedDict
 
 import param
 import lancet
 import topo
 import numbergen
 
+from specifications import SheetSpec, ProjectionSpec, ModelSpec
 from dataviews.collector import AttrTree
 from topo.misc.commandline import global_params
 
@@ -85,181 +85,6 @@ def order_projections(model, connection_order):
         if len(match) != 1:
             raise Exception("Could not order projection %r by property %r" % (spec, key))
         spec.sort_precedence = match[0]
-
-
-
-class Specification(object):
-    """
-    Specifications are templates for sheet or projection objects which
-    may be resolved to the corresponding simulation object once
-    instantiated.
-
-    All specifications have the following attribute:
-
-    :'parameters': Keyword argument dictionary specifying which
-    parameters should be passed to the sheet or projection object.
-    """
-
-    def update(self, **params):
-        """
-        Convenience method to easy update specification parameters.
-        """
-        self.parameters.update(params)
-
-    @property
-    def modified_parameters(self):
-        "Dictionary of modified specification parameters"
-        return {k:v for k, v in self.parameters.items()
-                if self.default_parameters[k] != v}
-
-
-    def resolve(self):
-        """
-        Returns the object in topo.sim corresponding to the string
-        name of this object, typically a Sheet or a Projection.
-
-        The appropriate object must be instantiated in topo.sim first.
-        """
-        from topo import sim # pyflakes:ignore (needed for eval)
-        return eval('sim.'+str(self))
-
-
-    def __lt__(self, other):
-        return self.sort_precedence < other.sort_precedence
-
-    def __eq__(self, other):
-        return self.sort_precedence == other.sort_precedence
-
-    def __init__(self, object_type):
-        self.parameters = {}
-        self.sort_precedence = 0
-        for param_name, default_value in object_type.params().items():
-            self.parameters[param_name]=default_value.default
-        self.default_parameters = dict(**self.parameters)
-
-    def summary(self, printed=True):
-        """
-        Generate a succinct summary of the Specification object. If
-        printed is set to True, the summary is printed, otherwise it
-        is returned as a string.
-        """
-        raise NotImplementedError
-
-
-class SheetSpec(Specification):
-    """
-    SheetSpec acts as a template for sheet objects.
-    """
-
-    name_ordering = ['eye','level', 'cone', 'polarity',
-                     'SF','opponent','surround']
-
-    @property
-    def level(self):
-        return self.properties['level']
-
-
-    def __init__(self, sheet_type, properties):
-        """
-        Initialize a SheetSpec object of a certain Sheet type with the
-        given properties.
-
-       :'sheet_type': Subclass of topo.base.sheet.Sheet.
-       :'properties': Dictionary specifying the properties of the
-       sheet. There must be a value given for the key 'level'.
-        """
-        super(SheetSpec,self).__init__(sheet_type)
-
-        if 'level' not in properties:
-            raise Exception("SheetSpec always requires 'level' property.")
-
-
-        properties = [(k, properties[k]) for k in self.name_ordering
-                      if k in properties]
-
-        self.sheet_type = sheet_type
-        self.properties = OrderedDict(properties)
-
-
-    def __call__(self):
-        """
-        Instantiate the sheet and register it in topo.sim.
-        """
-        properties = dict(self.parameters['properties'], **self.properties)
-        topo.sim[str(self)]=self.sheet_type(**dict(self.parameters,
-                                                   properties=properties))
-
-    def __str__(self):
-        """
-        Returns a string representation of the SheetSpec from the
-        properties values.
-        """
-        name=''
-        for prop in self.properties.itervalues():
-            name+=str(prop)
-
-        return name
-
-    def summary(self, printed=True):
-        summary = "%s : %s" % (self, self.sheet_type.name)
-        if printed: print summary
-        else:       return summary
-
-    def __repr__(self):
-        type_name = self.sheet_type.__name__
-        properties_repr = ', '.join("%r:%r" % (k,v) for (k,v)
-                                    in self.properties.items())
-        return "SheetSpec(%s, {%s})" % (type_name, properties_repr)
-
-
-
-class ProjectionSpec(Specification):
-    """
-    ProjectionSpec acts as a template for projection objects.
-    """
-
-    def __init__(self, projection_type, src, dest):
-        """
-        Initialize a ProjectionSpec object of a certain Projection
-        type with the given src and dest SheetSpecs.
-
-       :'projection_type': Subclass of topo.base.projection.Projection
-       :'src': SheetSpec of the source sheet
-       :'dest': SheetSpec of the destination sheet
-        """
-        super(ProjectionSpec, self).__init__(projection_type)
-
-        self.projection_type = projection_type
-        self.src = src
-        self.dest = dest
-
-        # These parameters are directly passed into topo.sim.connect()!
-        ignored_keys = ['src', 'dest']
-        self.parameters = dict((k,v) for (k,v) in self.parameters.items()
-                               if k not in ignored_keys)
-
-    def __call__(self):
-        """
-        Instantiate the projection and register it in topo.sim.
-        """
-        topo.sim.connect(str(self.src),str(self.dest),
-                         self.projection_type,
-                         **self.parameters)
-
-    def __str__(self):
-        return str(self.dest)+'.'+self.parameters['name']
-
-
-    def summary(self, printed=True):
-        summary = "%s [%s -> %s] : %s" % (self, self.src, self.dest,
-                                          self.projection_type.name)
-        if printed: print summary
-        else:       return summary
-
-    def __repr__(self):
-        type_name = self.projection_type.__name__
-        return "ProjectionSpec(%s, %r, %r)" % (type_name, self.src, self.dest)
-
 
 
 class ClassDecorator(object):
@@ -382,7 +207,6 @@ class Model(param.Parameterized):
     __abstract = True
 
     matchconditions = MatchConditions()
-
     sheet_decorators = set()
     projection_decorators = set()
 
@@ -435,21 +259,17 @@ class Model(param.Parameterized):
         return {k:v for k,v in self.get_param_values(onlychanged=True)}
 
 
-    def __init__(self, setup_options=True, register=True, time_dependent=True, **params):
+    def __init__(self, register=True, time_dependent=True, **params):
         numbergen.TimeAware.time_dependent = time_dependent
         if register:
             self._register_global_params(params)
         super(Model,self).__init__(**params)
-
         self._sheet_types = {}
         self._projection_types = {}
 
         self.attrs = AttrTree()
-        self.training_patterns = AttrTree()
-        self.sheets = AttrTree()
-        self.projections = AttrTree()
-
-        self.setup(setup_options)
+        # Training patterns need to be accessed by GeneratorSheets
+        self.attrs.training_patterns = AttrTree()
 
 
     def _register_global_params(self, params):
@@ -531,7 +351,7 @@ class Model(param.Parameterized):
     # Remaining methods should not need to be overridden #
     #====================================================#
 
-    def setup(self,setup_options):
+    def setup(self,setup_options=True):
         """
         This method can be used to setup certain parts of the
         submodel.  If setup_options=True, all setup methods are
@@ -550,16 +370,19 @@ class Model(param.Parameterized):
                                    'projections',
                                    'analysis']
 
+        model = ModelSpec(self)
         if setup_options==True:
             setup_options = available_setup_options
 
         if 'attributes' in setup_options:
-            self.attrs = self.setup_attributes(self.attrs)
+            self.attrs = self.setup_attributes(AttrTree())
 
         if 'training_patterns' in setup_options:
             training_patterns = self.setup_training_patterns()
             for name, training_pattern in training_patterns.items():
-                self.training_patterns.set_path(name, training_pattern)
+                model.training_patterns.set_path(name, training_pattern)
+
+            self.attrs.training_patterns = training_patterns
         if 'sheets' in setup_options:
             sheet_properties = self.setup_sheets()
 
@@ -579,23 +402,26 @@ class Model(param.Parameterized):
                     spec_properties = dict(level=level, **properties)
                     sheet_spec = SheetSpec(sheet_type, spec_properties)
                     sheet_spec.sort_precedence = ordering
-                    self.sheets.set_path(str(sheet_spec), sheet_spec)
+                    model.sheets.set_path(str(sheet_spec), sheet_spec)
 
-            self._update_sheet_spec_parameters()
+            model = self._update_sheet_spec_parameters(model)
+
         if 'projections' in setup_options:
-            self._compute_projection_specs()
+            model = self._compute_projection_specs(model)
         if 'analysis' in setup_options:
-            self._setup_analysis()
+            self.setup_analysis()
+        return model
 
 
-    def _update_sheet_spec_parameters(self):
-        for sheet_spec in self.sheets.path_items.values():
+    def _update_sheet_spec_parameters(self, model):
+        for sheet_spec in model.sheets.path_items.values():
             param_method = self.sheet_labels.get(sheet_spec.level, None)
             if not param_method:
                 raise Exception("Parameters for sheet level %r not specified" % sheet_spec.level)
 
-            updated_params = param_method(self,sheet_spec.properties)
+            updated_params = param_method(self, sheet_spec.properties)
             sheet_spec.update(**updated_params)
+        return model
 
 
     def _matchcondition_holds(self, matchconditions, src_sheet):
@@ -614,15 +440,15 @@ class Model(param.Parameterized):
 
         return matches
 
-    def _compute_projection_specs(self):
+    def _compute_projection_specs(self, model):
         """
         Loop through all possible combinations of SheetSpec objects in
         self.sheets If the src_sheet fulfills all criteria specified
         in dest_sheet.matchconditions, create a new ProjectionSpec
         object and add this item to self.projections.
         """
-        sheetspec_product = itertools.product(self.sheets.path_items.values(),
-                                              self.sheets.path_items.values())
+        sheetspec_product = itertools.product(model.sheets.path_items.values(),
+                                              model.sheets.path_items.values())
         for src_sheet, dest_sheet in sheetspec_product:
 
             has_matchcondition = (dest_sheet.level in self.matchconditions)
@@ -648,89 +474,19 @@ class Model(param.Parameterized):
                         proj.matchname = matchname
 
                         path = (str(dest_sheet), paramset['name'])
-                        self.projections.set_path(path, proj)
+                        model.projections.set_path(path, proj)
+        return model
 
 
-    def __call__(self,instantiate_options=True, verbose=False):
+    def __call__(self,setup_options=True, instantiate_options=True, verbose=False):
         """
-        Instantiates all sheets or projections in self.sheets or
-        self.projections and registers them in the topo.sim instance.
-
-        If instantiate_options=True, all items are initialised
-        instantiate_options can also be a list, whereas all list items
-        of available_instantiate_options are accepted.
-
-        Available instantiation options are: 'sheets' and
-        'projections'.
-
-        Please consult the docstring of the Model class for more
-        information about each instantiation option.
+        A convenient way to setup a model object, instantiate it and
+        return it.
         """
-        msglevel = self.message if verbose else self.debug
-        available_instantiate_options = ['sheets','projections']
-        if instantiate_options==True:
-            instantiate_options=available_instantiate_options
+        model = self.setup(setup_options)
+        model(instantiate_options, verbose)
+        return model
 
-        if 'sheets' in instantiate_options:
-            for sheet_spec in self.sheets.path_items.itervalues():
-                msglevel('Level ' + sheet_spec.level + ': Sheet ' + str(sheet_spec))
-                sheet_spec()
-
-        if 'projections' in instantiate_options:
-            for proj in sorted(self.projections):
-                msglevel('Match: ' + proj.matchname + ': Connection ' + str(proj.src) + \
-                             '->' + str(proj.dest) + ' ' + proj.parameters['name'])
-                proj()
-
-    def summary(self, printed=True):
-
-        heading_line = '=' * len(self.name)
-        summary = [heading_line, self.name, heading_line, '']
-
-        for sheet_spec in sorted(self.sheets):
-            summary.append(sheet_spec.summary(printed=False))
-            projections = [proj for proj in self.projections
-                           if str(proj).startswith(str(sheet_spec))]
-            for projection_spec in sorted(projections, key=lambda p: str(p)):
-                summary.append("   " + projection_spec.summary(printed=False))
-            summary.append('')
-
-        if printed: print "\n".join(summary)
-        else:       return "\n".join(summary)
-
-
-    def __str__(self):
-        return self.name
-
-
-    def _repr_pretty_(self, p, cycle):
-        p.text(self.summary(printed=False))
-
-
-    def modifications(self, components=['model', 'sheets', 'projections']):
-        """
-        Display the names of all modified parameters for the specified
-        set of components.
-
-        By default all modified parameters are listed - first with the
-        model parameters, then the sheet parameters and lastly the
-        projection parameters.
-        """
-        mapping = {'model': [self],
-                   'sheets':self.sheets,
-                   'projections':self.projections}
-
-        lines = []
-        for component in components:
-            heading = "=" * len(component)
-            lines.extend([heading, component.capitalize(), heading, ''])
-            specs = mapping[component]
-            padding = max(len(str(spec)) for spec in specs)
-            for spec in sorted(specs):
-                modified = [str(el) for el in sorted(spec.modified_parameters)]
-                lines.append("%s : [%s]" % (str(spec).ljust(padding), ", ".join(modified)))
-            lines.append('')
-        print "\n".join(lines)
 
 
 # Register the sheets and projections available in Topographica

--- a/topo/submodel/earlyvision.py
+++ b/topo/submodel/earlyvision.py
@@ -190,9 +190,9 @@ class EarlyVisionModel(VisualInputModel):
                                   + self.v1aff_radius*self.sf_spacing**(max(self.attrs.SF)-1)
                                   + self.lgnaff_radius*self.sf_spacing**(max(self.attrs.SF)-1)
                                   + self.lgnlateral_radius),
-            input_generator=self.training_patterns[properties['eye']+'Retina'
-                                                   if 'eye' in properties
-                                                   else 'Retina'])
+            input_generator=self.attrs.training_patterns[properties['eye']+'Retina'
+                                                         if 'eye' in properties
+                                                         else 'Retina'])
 
 
     @Model.SettlingCFSheet

--- a/topo/submodel/gcal.py
+++ b/topo/submodel/gcal.py
@@ -186,16 +186,17 @@ class ExamplesGCAL(ModelGCAL):
 
 
     def setup(self,setup_options):
-        super(ExamplesGCAL, self).setup(setup_options)
+        model = super(ExamplesGCAL, self).setup(setup_options)
         if setup_options is True or 'sheets' in setup_options:
-            self.sheets.Retina.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+1.125))
-            self.sheets.LGNOn.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+0.75))
-            self.sheets.LGNOff.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+0.75))
-            self.sheets.V1.update(nominal_density=48)
+            model.sheets.Retina.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+1.125))
+            model.sheets.LGNOn.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+0.75))
+            model.sheets.LGNOff.update(nominal_bounds=sheet.BoundingBox(radius=self.area/2.0+0.75))
+            model.sheets.V1.update(nominal_density=48)
         if setup_options is True or 'projections' in setup_options:
-            order_projections(self, ['afferent',
-                                     'lateral_gain_control',
-                                     ('V1_afferent', {'polarity':'On'}),
-                                     ('V1_afferent', {'polarity':'Off'}),
-                                     'lateral_excitatory',
-                                     'lateral_inhibitory'])
+            order_projections(model, ['afferent',
+                                      'lateral_gain_control',
+                                      ('V1_afferent', {'polarity':'On'}),
+                                      ('V1_afferent', {'polarity':'Off'}),
+                                      'lateral_excitatory',
+                                      'lateral_inhibitory'])
+        return model

--- a/topo/submodel/specifications.py
+++ b/topo/submodel/specifications.py
@@ -1,0 +1,287 @@
+"""
+A set of objects that allows declarative specification of a model
+including training patterns, sheets and projections.
+
+The components of a model specification can be individually inspected,
+modified, resolved or instantiated.
+"""
+
+import topo
+import param
+
+from dataviews.collector import AttrTree
+from collections import OrderedDict
+
+
+class Specification(param.Parameterized):
+    """
+    Specifications are templates for sheet or projection objects which
+    may be resolved to the corresponding simulation object once
+    instantiated.
+
+    All specifications have the following attribute:
+
+    :'parameters': Keyword argument dictionary specifying which
+    parameters should be passed to the sheet or projection object.
+    """
+
+    def update(self, **params):
+        """
+        Convenience method to easy update specification parameters.
+        """
+        self.parameters.update(params)
+
+    @property
+    def modified_parameters(self):
+        "Dictionary of modified specification parameters"
+        return {k:v for k, v in self.parameters.items()
+                if self.default_parameters[k] != v}
+
+
+    def resolve(self):
+        """
+        Returns the object in topo.sim corresponding to the string
+        name of this object, typically a Sheet or a Projection.
+
+        The appropriate object must be instantiated in topo.sim first.
+        """
+        from topo import sim # pyflakes:ignore (needed for eval)
+        return eval('sim.'+str(self))
+
+
+    def __lt__(self, other):
+        return self.sort_precedence < other.sort_precedence
+
+    def __eq__(self, other):
+        return self.sort_precedence == other.sort_precedence
+
+    def __init__(self, object_type):
+        self.parameters = {}
+        self.sort_precedence = 0
+        for param_name, default_value in object_type.params().items():
+            self.parameters[param_name]=default_value.default
+        self.default_parameters = dict(**self.parameters)
+
+    def summary(self, printed=True):
+        """
+        Generate a succinct summary of the Specification object. If
+        printed is set to True, the summary is printed, otherwise it
+        is returned as a string.
+        """
+        raise NotImplementedError
+
+
+
+class SheetSpec(Specification):
+    """
+    SheetSpec acts as a template for sheet objects.
+    """
+
+    name_ordering = ['eye','level', 'cone', 'polarity',
+                     'SF','opponent','surround']
+
+    @property
+    def level(self):
+        return self.properties['level']
+
+
+    def __init__(self, sheet_type, properties):
+        """
+        Initialize a SheetSpec object of a certain Sheet type with the
+        given properties.
+
+       :'sheet_type': Subclass of topo.base.sheet.Sheet.
+       :'properties': Dictionary specifying the properties of the
+       sheet. There must be a value given for the key 'level'.
+        """
+        super(SheetSpec,self).__init__(sheet_type)
+
+        if 'level' not in properties:
+            raise Exception("SheetSpec always requires 'level' property.")
+
+
+        properties = [(k, properties[k]) for k in self.name_ordering
+                      if k in properties]
+
+        self.sheet_type = sheet_type
+        self.properties = OrderedDict(properties)
+
+
+    def __call__(self):
+        """
+        Instantiate the sheet and register it in topo.sim.
+        """
+        properties = dict(self.parameters['properties'], **self.properties)
+        topo.sim[str(self)]=self.sheet_type(**dict(self.parameters,
+                                                   properties=properties))
+
+    def __str__(self):
+        """
+        Returns a string representation of the SheetSpec from the
+        properties values.
+        """
+        name=''
+        for prop in self.properties.itervalues():
+            name+=str(prop)
+
+        return name
+
+    def summary(self, printed=True):
+        summary = "%s : %s" % (self, self.sheet_type.name)
+        if printed: print summary
+        else:       return summary
+
+    def __repr__(self):
+        type_name = self.sheet_type.__name__
+        properties_repr = ', '.join("%r:%r" % (k,v) for (k,v)
+                                    in self.properties.items())
+        return "SheetSpec(%s, {%s})" % (type_name, properties_repr)
+
+
+
+class ProjectionSpec(Specification):
+    """
+    ProjectionSpec acts as a template for projection objects.
+    """
+
+    def __init__(self, projection_type, src, dest):
+        """
+        Initialize a ProjectionSpec object of a certain Projection
+        type with the given src and dest SheetSpecs.
+
+       :'projection_type': Subclass of topo.base.projection.Projection
+       :'src': SheetSpec of the source sheet
+       :'dest': SheetSpec of the destination sheet
+        """
+        super(ProjectionSpec, self).__init__(projection_type)
+
+        self.projection_type = projection_type
+        self.src = src
+        self.dest = dest
+
+        # These parameters are directly passed into topo.sim.connect()!
+        ignored_keys = ['src', 'dest']
+        self.parameters = dict((k,v) for (k,v) in self.parameters.items()
+                               if k not in ignored_keys)
+
+    def __call__(self):
+        """
+        Instantiate the projection and register it in topo.sim.
+        """
+        topo.sim.connect(str(self.src),str(self.dest),
+                         self.projection_type,
+                         **self.parameters)
+
+    def __str__(self):
+        return str(self.dest)+'.'+self.parameters['name']
+
+
+    def summary(self, printed=True):
+        summary = "%s [%s -> %s] : %s" % (self, self.src, self.dest,
+                                          self.projection_type.name)
+        if printed: print summary
+        else:       return summary
+
+    def __repr__(self):
+        type_name = self.projection_type.__name__
+        return "ProjectionSpec(%s, %r, %r)" % (type_name, self.src, self.dest)
+
+
+
+class ModelSpec(Specification):
+    """
+    ModelSpec acts as a template for Topographica model including
+    training patterns, sheets and projections.
+    """
+
+    def __init__(self, model):
+        self.training_patterns = AttrTree()
+        self.sheets = AttrTree()
+        self.projections = AttrTree()
+        super(ModelSpec, self).__init__(model)
+        self.model= model
+
+    def resolve(self):
+        from topo import sim     # pyflakes:ignore (needed for eval)
+        return eval('sim.model')
+
+    def __call__(self, instantiate_options=True, verbose=False):
+        """
+        Instantiates all sheets or projections in self.sheets or
+        self.projections and registers them in the topo.sim instance.
+
+        If instantiate_options=True, all items are initialised
+        instantiate_options can also be a list, whereas all list items
+        of available_instantiate_options are accepted.
+
+        Available instantiation options are: 'sheets' and
+        'projections'.
+
+        Please consult the docstring of the Model class for more
+        information about each instantiation option.
+        """
+        msglevel = self.message if verbose else self.debug
+        available_instantiate_options = ['sheets','projections']
+        if instantiate_options==True:
+            instantiate_options=available_instantiate_options
+
+        if 'sheets' in instantiate_options:
+            for sheet_spec in self.sheets.path_items.itervalues():
+                msglevel('Level ' + sheet_spec.level + ': Sheet ' + str(sheet_spec))
+                sheet_spec()
+
+        if 'projections' in instantiate_options:
+            for proj in sorted(self.projections):
+                msglevel('Match: ' + proj.matchname + ': Connection ' + str(proj.src) + \
+                             '->' + str(proj.dest) + ' ' + proj.parameters['name'])
+                proj()
+
+
+    def summary(self, printed=True):
+
+        heading_line = '=' * len(self.name)
+        summary = [heading_line, self.name, heading_line, '']
+
+        for sheet_spec in sorted(self.sheets):
+            summary.append(sheet_spec.summary(printed=False))
+            projections = [proj for proj in self.projections
+                           if str(proj).startswith(str(sheet_spec))]
+            for projection_spec in sorted(projections, key=lambda p: str(p)):
+                summary.append("   " + projection_spec.summary(printed=False))
+            summary.append('')
+
+        if printed: print "\n".join(summary)
+        else:       return "\n".join(summary)
+
+
+    def __str__(self):
+        return self.model.__class__.__name__
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(self.summary(printed=False))
+
+
+    def modifications(self, components=['model', 'sheets', 'projections']):
+        """
+        Display the names of all modified parameters for the specified
+        set of components.
+
+        By default all modified parameters are listed - first with the
+        model parameters, then the sheet parameters and lastly the
+        projection parameters.
+        """
+        mapping = {'model': [self],
+                   'sheets':self.sheets,
+                   'projections':self.projections}
+
+        lines = []
+        for component in components:
+            heading = "=" * len(component)
+            lines.extend([heading, component.capitalize(), heading, ''])
+            specs = mapping[component]
+            padding = max(len(str(spec)) for spec in specs)
+            for spec in sorted(specs):
+                modified = [str(el) for el in sorted(spec.modified_parameters)]
+                lines.append("%s : [%s]" % (str(spec).ljust(padding), ", ".join(modified)))
+            lines.append('')
+        print "\n".join(lines)


### PR DESCRIPTION
This PR fixes some annoyances with the submodel system:
- `topo.sim.model.V1` does not refer to a declarative `SheetSpec` object - instead this points to a method called 'V1'. Although important for defining the model class, this isn't particularly useful to the user once the model object has been created. It is confusing to have `model.V1` and `model.sheets.V1` on the same object.
- The subclasses of `Model` were a mix of declarative objects (e.g. `model.sheets` and `model.projections`) and the decorated methods used to create those objects. In contrast, `SheetSpec` and `ProjectionSpec` existed as distinct declarative objects (which can be called to be instantiated).

The solution proposed here is to introduce a `ModelSpec` which is the declarative counterpart to a `Model` definition class. Just like `SheetSpec` and `ProjectionSpec` it can be called to instantiate the corresponding model. This helps make a clearer distinction between the model definition (code), the model specification (lightweight, declarative object) and simulation components (memory hungry objects).
