### PR TITLE
Replaced nose.plugins.skip.SkipTest with unittest.SkipTest

### DIFF
--- a/topo/misc/ipython.py
+++ b/topo/misc/ipython.py
@@ -16,7 +16,7 @@ try:
     import IPython # pyflakes:ignore (Required import)
     from IPython.core.magic import Magics, magics_class, line_magic
 except:
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
     raise SkipTest("IPython extension requires IPython >= 0.12")
 
 

--- a/topo/misc/unitsupport.py
+++ b/topo/misc/unitsupport.py
@@ -10,7 +10,7 @@ from param.parameterized import bothmethod
 from topo import sheet, pattern, base, numbergen
 import numpy as np
 
-from nose.plugins.skip import SkipTest
+from unittest import SkipTest
 
 got_unum = False; got_pq=False
 

--- a/topo/optimized/compile.py
+++ b/topo/optimized/compile.py
@@ -7,7 +7,7 @@ import numpy
 try:
     from Cython.Distutils import build_ext
 except:
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
     raise SkipTest('Cython could not be imported, '
                    'cannot compile sparse components.')
 from distutils.core import setup

--- a/topo/sparse/compile.py
+++ b/topo/sparse/compile.py
@@ -7,7 +7,7 @@ import numpy
 try:
     from Cython.Distutils import build_ext
 except:
-    from nose.plugins.skip import SkipTest
+    from unittest import SkipTest
     raise SkipTest('Cython could not be imported, '
                    'cannot compile sparse components.')
 from distutils.core import setup


### PR DESCRIPTION
To avoid dependency on nose (part of #594).

Topographica still depends on nose for tests, but that's ok (right?).

However, what about the ipython-related files in dataviews and param? I guess they are all optional, so it doesn't matter anyway. Just in case, I made a temporary branch of dataviews so you can see what I mean: https://github.com/ioam/dataviews/compare/skiptest_from_unittest. I'll delete that branch once someone lets me know what to do.
