### PR TITLE
Make IPython extension optional.

### DIFF
--- a/topo/misc/commandline.py
+++ b/topo/misc/commandline.py
@@ -7,9 +7,8 @@ Topographica files within a separate Python.
 
 
 from optparse import OptionParser
-from unittest import SkipTest
 
-import sys, __main__, math, os, re
+import sys, __main__, math, os, re, traceback
 
 import topo
 
@@ -785,9 +784,9 @@ def process_argv(argv):
             # Load Topographica IPython extension in embedded shell
             try:
                 ipshell.extension_manager.load_extension('topo.misc.ipython')
-            except Exception as e:
+            except:
                 cmdline_main.warning(
-                    "Could not load IPython extension 'topo.misc.ipython': %s"%e)
+                    "Could not load IPython extension 'topo.misc.ipython'; ignored error was:\n%s"%traceback.format_exc())
                 
             ipshell()
 


### PR DESCRIPTION
Part of #594.

I wondered about catching all errors rather than just SkipTest - what do you think? (Also, feels odd to be importing unittest here and elsewhere, but I guess lots of nose importing has been happening so it's not too bad...)

Not sure about the message, too. (Could maybe print out the caught exception instead?)
