### PR TITLE
Remove various confusing and apparently out-of-date ignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 bin
 lib
 local/*
-external/*
 emacslog
 include
 info
@@ -26,9 +25,6 @@ models/stevens.jn13/jn13_figures/output/Fig*
 models/stevens.jn13/jn13_figures/output/build_dir
 models/stevens.jn13/
 platform/ipython
-doc/Tutorials/*.rst
-doc/Reference_Manual/*.rst
 /doc/test_data
-/*.ipynb
+/doc/_build
 topo/optimized/optimized.c
-notebooks/

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,3 +1,0 @@
-_build
-Reference_Manual/*-module.rst
-*.pyc


### PR DESCRIPTION
This is a PR for discussion rather than immediate merging, because probably I'm not right about all of these, but e.g. the ignoring of notebooks in the root directory confused me, so I looked at .gitignore and went down a bit of a rabbit hole... 

(listed in order they appear in the diff, just about)

1. (line 16) Why ignore new files added to external (``external/*``)?
2. (line 29) Why ignore new .rst files added to doc/Tutorials? If I make a new file here, why wouldn't I want to hear about it from git?
3. (line 30) Why ignore new .rst files added to doc/Reference_Manual? Maybe this directory is supposed to have only the existing (tracked) ``index.rst`` plus generated files, i.e. no new human-added files. And I guess you want to ignore generated .rst files (since there's also ``Reference_Manual/*-module.rst`` in the .gitignore for doc), in which case probably I shouldn't have removed this line.
4. (line 32) Why ignore notebooks created in the root directory?
5. (line 34) ``notebooks`` directory is no longer used, right? Or I've missed it?
6. Why have a doc/.gitignore when none of the other directories have their own .gitignore, and there are only a couple of things to ignore? I've moved ``_build`` to the main .gitignore, removed ``*.pyc`` (redundant), and removed what I think might be out-of-date ``Reference_Manual/*-module.rst`` (might be wrong about that...).

Also, you can see things like ``include`` (line 18) will cause anything called ``include`` to be ignored throughout the repository, whereas e.g. ``/doc/_build`` is being explicit about ignoring only ``doc/build`` from the root, not from anywhere else ``doc/_build`` might appear. Probably worth going through each and deciding which it's supposed to be.
