### PR TITLE
Port to latest holoviews

### DIFF
--- a/topo/__init__.py
+++ b/topo/__init__.py
@@ -53,7 +53,6 @@ from subprocess import Popen, PIPE #pyflakes:ignore (has to do with Python versi
 
 import os
 import param
-import imagen
 
 
 def version_int(v):

--- a/topo/analysis/__init__.py
+++ b/topo/analysis/__init__.py
@@ -7,7 +7,7 @@ and sets the appropriate Topographica-specific hooks.
 
 import numpy as np
 
-from holoviews.interface.collector import Reference
+from holoviews.core.io import Reference
 from holoviews import HSV, Image
 from holoviews.core.options import Compositor
 from holoviews.ipython import IPTestCase

--- a/topo/analysis/__init__.py
+++ b/topo/analysis/__init__.py
@@ -29,10 +29,10 @@ from command import measure_cog
 
 
 
-CoG_spec = "Image.X CoG * Image.Y CoG * Image.BlueChannel"
-XYCoG = chain.instance(group='XYCoG', name='XYCoG',
-                       operations = [image_overlay.instance(spec=CoG_spec), factory.instance()])
-Compositor.register(Compositor("Image.X CoG * Image.Y CoG", XYCoG, 'XYCoG', 'display'))
+# CoG_spec = "Image.X CoG * Image.Y CoG * Image.BlueChannel"
+# XYCoG = chain.instance(group='XYCoG', name='XYCoG',
+#                        operations = [image_overlay.instance(spec=CoG_spec), factory.instance()])
+# Compositor.register(Compositor("Image.X CoG * Image.Y CoG", XYCoG, 'XYCoG', 'display'))
 
 
 import param

--- a/topo/analysis/command.py
+++ b/topo/analysis/command.py
@@ -205,9 +205,9 @@ class measure_cog(ParameterizedFunction):
 
         timestamp = topo.sim.time()
         lbrt = sheet.bounds.lbrt()
-        xsv = Image(xcog, sheet.bounds, label=proj.name, group='X CoG',
+        xsv = Image(xcog, bounds=sheet.bounds, label=proj.name, group='X CoG',
                     vdims=[Dimension('X CoG', range=(lbrt[0], lbrt[2]))])
-        ysv = Image(ycog, sheet.bounds, label=proj.name, group='Y CoG',
+        ysv = Image(ycog, bounds=sheet.bounds, label=proj.name, group='Y CoG',
                     vdims=[Dimension('Y CoG', range=(lbrt[1], lbrt[3]))])
 
         lines = []

--- a/topo/analysis/featureresponses.py
+++ b/topo/analysis/featureresponses.py
@@ -54,7 +54,7 @@ def update_sheet_activity(sheet_name, force=False):
     if not view:
         im = Image(np.array(sheet.activity), bounds=sheet.bounds)
         im.metadata=metadata
-        view = HoloMap((time, im), key_dimensions=[Time])
+        view = HoloMap((time, im), kdims=[Time])
         view.metadata = metadata
         sheet.views.Maps[name] = view
     else:

--- a/topo/analysis/featureresponses.py
+++ b/topo/analysis/featureresponses.py
@@ -16,7 +16,7 @@ from param.parameterized import ParamOverrides
 
 from holoviews import Image, HoloMap
 from holoviews.ipython.widgets import ProgressBar
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 
 import topo
 import topo.base.sheetcoords
@@ -52,14 +52,14 @@ def update_sheet_activity(sheet_name, force=False):
                         src_name=sheet.name, shape=sheet.activity.shape,
                         timestamp=time)
     if not view:
-        im = Image(np.array(sheet.activity), sheet.bounds)
+        im = Image(np.array(sheet.activity), bounds=sheet.bounds)
         im.metadata=metadata
         view = HoloMap((time, im), key_dimensions=[Time])
         view.metadata = metadata
         sheet.views.Maps[name] = view
     else:
         if force or view.range('Time')[1] < time:
-            im = Image(np.array(sheet.activity), sheet.bounds)
+            im = Image(np.array(sheet.activity), bounds=sheet.bounds)
             im.metadata=metadata
             view[time] = im
     return view

--- a/topo/analysis/weights.py
+++ b/topo/analysis/weights.py
@@ -105,7 +105,7 @@ class WeightIsotropy(TreeOperation):
 
             # Construct Elements
             label =' '.join([s, p])
-            histogram = Histogram(bins, edges, group="Weight Isotropy",
+            histogram = Histogram((edges, bins), group="Weight Isotropy",
                                   kdims=[Dimension('Azimuth')], label=label)
             layout.WeightIsotropy['_'.join([s, p])] = histogram
         return layout
@@ -148,7 +148,7 @@ class WeightDistribution(TreeOperation):
             featurepref = preferences[s]
             if isinstance(featurepref, HoloMap):
                 featurepref = featurepref.last
-            feature = featurepref.value_dimensions[0]
+            feature = featurepref.vdims[0]
             feature_arr = featurepref.data.flat
             cfs = tree.CFs[p]
             deltas, weights = [], []
@@ -171,7 +171,7 @@ class WeightDistribution(TreeOperation):
             # Construct Elements
             label = ' '.join([s,p])
             group = '%s Weight Distribution' % self.p.feature
-            histogram = Histogram(bins, edges, group=group, label=label,
+            histogram = Histogram((edges, bins), group=group, label=label,
                                   kdims=[' '.join([self.p.feature, 'Difference'])],
                                   vdims=['Weight'])
 

--- a/topo/base/cf.py
+++ b/topo/base/cf.py
@@ -23,7 +23,7 @@ import numpy as np
 
 import param
 from holoviews import GridSpace, Dimension, HoloMap, Layout
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 from holoviews.core import BoundingBox, BoundingRegionParameter, Slice
 
 import patterngenerator
@@ -782,7 +782,7 @@ class CFProjection(Projection):
             matrix_data = cf.weights.copy()
             bounds = roi_bounds
 
-        sv = CFView(matrix_data, bounds, situated_bounds=situated_bounds,
+        sv = CFView(matrix_data, bounds=bounds, situated_bounds=situated_bounds,
                     input_sheet_slice=(r1, r2, c1, c2), roi_bounds=roi_bounds,
                     label=self.name, group='CF Weight')
         sv.metadata=AttrDict(timestamp=timestamp)

--- a/topo/base/generatorsheet.py
+++ b/topo/base/generatorsheet.py
@@ -8,7 +8,7 @@ from topo.base.sheet import Sheet
 from topo.base.patterngenerator import PatternGenerator,Constant
 from topo.base.simulation import FunctionEvent, PeriodicEventSequence
 
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 from holoviews import Image
 
 import numpy as np
@@ -279,7 +279,7 @@ class ChannelGeneratorSheet(GeneratorSheet):
         else:
             arr = self.activity.copy()
 
-        im = Image(arr, self.bounds,
+        im = Image(arr, bounds=self.bounds,
                    label=self.name+' Activity', group='Activity')[coords]
         im.metadata=metadata
         return im

--- a/topo/base/projection.py
+++ b/topo/base/projection.py
@@ -12,7 +12,7 @@ from param.parameterized import overridable_property
 
 from imagen import Disk
 from holoviews import Image, Layout
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 
 from sheet import Sheet
 from simulation import EPConnection
@@ -326,7 +326,7 @@ class Projection(EPConnection):
         """Returns the activity in a single projection"""
         if timestamp is None:
             timestamp = self.src.simulation.time()
-        im = Image(self.activity.copy(), self.dest.bounds,
+        im = Image(self.activity.copy(), bounds=self.dest.bounds,
                    label=self.name, group='Activity')
         im.metadata=AttrDict(proj_src_name=self.src.name,
                              precedence=self.src.precedence,

--- a/topo/base/sheet.py
+++ b/topo/base/sheet.py
@@ -24,7 +24,7 @@ import param
 
 from holoviews import Image, Layout
 from holoviews.core import BoundingBox, BoundingRegionParameter, SheetCoordinateSystem
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 
 from simulation import EventProcessor
 from functionfamily import TransferFn
@@ -309,7 +309,7 @@ class Sheet(EventProcessor,SheetCoordinateSystem):  # pylint: disable-msg=W0223
                             row_precedence=self.row_precedence,
                             timestamp=self.simulation.time())
 
-        image = Image(self.activity.copy(), self.bounds,
+        image = Image(self.activity.copy(), bounds=self.bounds,
                    label=self.name, group='Activity')[coords]
         image.metadata=metadata
         return image

--- a/topo/base/sheetview.py
+++ b/topo/base/sheetview.py
@@ -117,7 +117,7 @@ class CFView(Image):
         r1, r2, c1, c2 = self.input_sheet_slice
         data[r1:r2, c1:c2] = self.data
 
-        return CFView(data, self.situated_bounds, roi_bounds=self.bounds,
+        return CFView(data, bounds=self.situated_bounds, roi_bounds=self.bounds,
                       situated_bounds=self.situated_bounds,
                       label=self.label, group=self.group)
 

--- a/topo/base/simulation.py
+++ b/topo/base/simulation.py
@@ -56,7 +56,7 @@ from copy import copy, deepcopy
 import time
 import bisect
 
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 
 #: Default path to the current simulation, from main
 #: Only to be used by script_repr(), to allow it to generate

--- a/topo/misc/commandline.py
+++ b/topo/misc/commandline.py
@@ -477,8 +477,30 @@ topo_parser.add_option("-o","--outputpath",action="callback",callback=o_action,t
 		       help="set the default output path")
 
 
+if ipython_shell_interface == "InteractiveShellEmbed":
+    # IPython 0.11 and later
+
+    config = Config()
+    if ipython_prompt_interface == "PromptManager":
+        config.PromptManager.in_template = CommandPrompt.get_format()
+        config.PromptManager.in2_template = CommandPrompt2.get_format()
+        config.PromptManager.out_template = OutputPrompt.get_format()
+        config.InteractiveShell.confirm_exit = False
+    else:
+        config.TerminalInteractiveShell.prompts_class=IPythonCommandPrompt
+        config.InteractiveShell.confirm_exit = False
+        
+
 def gui(start=True,exit_on_quit=True):
     """Start the GUI as if -g were supplied in the command used to launch Topographica."""
+    # 
+    # To integrate with Tk we need to 
+    # create ipshell *before* calling enable_gui
+    # it is important that you use instance(), instead of the class
+    # constructor, so that it creates the global InteractiveShell singleton
+
+    IPShell.instance(config=config)
+
     try:
         # Need to connect Tk before import of pyplot
         import matplotlib
@@ -742,25 +764,6 @@ def exec_startup_files():
             cmdline_main.warning("Ignoring %s; location for startup file is %s (UNIX/Linux/Mac OS X) or %s (Windows)."%(startup_file,rcpath,inipath))
 
 ### Execute what is specified by the options.
-
-if ipython_shell_interface == "InteractiveShellEmbed":
-    # IPython 0.11 and later
-
-    # To integrate with Tk we need to 
-    # create ipshell *before* calling enable_gui
-    # it is important that you use instance(), instead of the class
-    # constructor, so that it creates the global InteractiveShell singleton
-    config = Config()
-    if ipython_prompt_interface == "PromptManager":
-        config.PromptManager.in_template = CommandPrompt.get_format()
-        config.PromptManager.in2_template = CommandPrompt2.get_format()
-        config.PromptManager.out_template = OutputPrompt.get_format()
-        config.InteractiveShell.confirm_exit = False
-    else:
-        config.TerminalInteractiveShell.prompts_class=IPythonCommandPrompt
-        config.InteractiveShell.confirm_exit = False
-        
-    ipshell = IPShell.instance(config=config)
 
 def process_argv(argv):
     """

--- a/topo/misc/commandline.py
+++ b/topo/misc/commandline.py
@@ -42,7 +42,7 @@ try:
          from IPython.terminal.embed import InteractiveShellEmbed as IPShell
     except ImportError: # Prior to IPython 1.0, InteractiveShellEmbed was found in the frontend package
         from IPython.frontend.terminal.embed import InteractiveShellEmbed as IPShell # pyflakes:ignore (try/except import)
-    from IPython.config.loader import Config
+    from traitlets.config.loader import Config
     ipython_shell_interface = "InteractiveShellEmbed"
     try:
         from IPython.core.prompts import PromptManager  # pyflakes:ignore (try/except import)

--- a/topo/misc/lancext.py
+++ b/topo/misc/lancext.py
@@ -15,7 +15,7 @@ import numpy.version as np_version
 import param
 
 from holoviews import NdMapping, Layout
-from holoviews.interface.collector import Collector
+from featuremapper.collector import Collector
 from holoviews.core.element import Collator
 from holoviews.core.io import Pickler
 

--- a/topo/submodel/specifications.py
+++ b/topo/submodel/specifications.py
@@ -57,8 +57,13 @@ class Specification(param.Parameterized):
 
 
     def __eq__(self, other):
-        return self.sort_precedence == other.sort_precedence
-
+        try:
+            return self.sort_precedence == other.sort_precedence
+        except Exception as e:
+            # Change in holoviews
+            if type(other) == str:
+                return False
+            raise e
 
     def __init__(self, object_type):
         self._object_type = object_type

--- a/topo/tests/unit/testcf.py
+++ b/topo/tests/unit/testcf.py
@@ -1,6 +1,10 @@
 import unittest
 import numpy
 
+# Need to load TkAgg before any calls to pyplot in the imports
+import matplotlib
+matplotlib.use("TkAgg")
+
 from topo.base.simulation import Simulation
 from topo.base.boundingregion import BoundingBox
 from topo.base.cf import CFIter,ResizableCFProjection,CFSheet

--- a/topo/tests/unit/testgmpynumber.py
+++ b/topo/tests/unit/testgmpynumber.py
@@ -1,6 +1,7 @@
 import os, sys
 sys.path = [os.path.join(os.getcwd(), '..', '..', '..', 'external', 'param')] + sys.path
 
+import unittest
 import param
 
 from nose.plugins.skip import SkipTest
@@ -11,32 +12,36 @@ except ImportError:
 
 mpq = gmpy.mpq
 
-class TestPO1(param.Parameterized):
-    z = param.Number(default=mpq(1),bounds=(-1,1))
+class TestGMPY(unittest.TestCase):
 
-t1 = TestPO1()
+    def setUp(self):
+        
+        class TestPO1(param.Parameterized):
+            z = param.Number(default=mpq(1),bounds=(-1,1))
 
+        self.t1 = TestPO1()
 
-### Check Number accepts gmpy.mpq
-assert isinstance(t1.z,type(mpq(1))) and t1.z==1
+    def testNumberAcceptsmpq(self):
+        ### Check Number accepts gmpy.mpq
+        assert isinstance(self.t1.z,type(mpq(1))) and self.t1.z==1
+    
+        try:
+            self.t1.z+=1
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Number's bounds were not respected.")
 
-try:
-   t1.z+=1
-except ValueError:
-   pass
-else:
-   raise AssertionError("Number's bounds were not respected.")
-
-
-### Check gmpy works for simulation time
-import topo
-original_type = topo.sim.time.time_type
-topo.sim.initialized=False
-assert topo.sim.time(0.0, time_type = mpq) == mpq(0,1)
-t1.z = mpq(0.999)
-t1.z-=topo.sim.convert_to_time_type(0.0004)
-assert t1.z == mpq(4993,5000)
-topo.sim.time(0.0, time_type = original_type)
-topo.sim.initialized=True
+    def testGMPWorks(self):
+        ### Check gmpy works for simulation time
+        import topo
+        original_type = topo.sim.time.time_type
+        topo.sim.initialized=False
+        assert topo.sim.time(0.0, time_type = mpq) == mpq(0,1)
+        self.t1.z = mpq(0.999)
+        self.t1.z-=topo.sim.convert_to_time_type(0.0004)
+        assert self.t1.z == mpq(4993,5000)
+        topo.sim.time(0.0, time_type = original_type)
+        topo.sim.initialized=True
 
 

--- a/topo/tests/unit/testparameterizedobject_tk.py
+++ b/topo/tests/unit/testparameterizedobject_tk.py
@@ -6,13 +6,6 @@ Tests for the tkParameterized classes.
 ## CB: add test for change of po
 import __main__
 import unittest
-from Tkinter import Frame,Toplevel
-
-import param
-import paramtk as tk
-from imagen import PatternGenerator, Gaussian, Ring, Rectangle
-
-
 # CEBALERT: will be replaced with call to param.tk.initialize() when
 # param.tk doesn't depend on anything from tkgui.__init__ (plus this
 # test will move to the param package...)
@@ -24,6 +17,14 @@ if os.getenv("DISPLAY"):
     import topo.tkgui
     topo.tkgui.start()
 else: raise SkipTest("No DISPLAY found")
+
+from Tkinter import Frame,Toplevel
+
+from imagen import PatternGenerator, Gaussian, Ring, Rectangle
+
+
+import param
+import paramtk as tk
 
 @nottest
 class SomeFrame(tk.TkParameterized,Frame):

--- a/topo/tests/unit/testplot.py
+++ b/topo/tests/unit/testplot.py
@@ -74,7 +74,7 @@ class TestPlot(unittest.TestCase):
         ### Find a way to assign randomly the matrix.
         self.matrix1 = np.zeros((10,10),dtype=np.float) + np.random.random((10,10))
         self.bounds1 = BoundingBox(points=((-0.5,-0.5),(0.5,0.5)))
-        im = Image(self.matrix1, self.bounds1)
+        im = Image(self.matrix1, bounds=self.bounds1)
         im.metadata=metadata
         self.sheet_view1 = NdMapping((None, im))
         self.sheet_view1.metadata = AttrDict(src_name='TestInputParam',
@@ -87,7 +87,7 @@ class TestPlot(unittest.TestCase):
         ### Find a way to assign randomly the matrix.
         self.matrix2 = np.zeros((10,10),dtype=np.float) + 0.3
         self.bounds2 = BoundingBox(points=((-0.5,-0.5),(0.5,0.5)))
-        im = Image(self.matrix2, self.bounds2)
+        im = Image(self.matrix2, bounds=self.bounds2)
         im.metadata=metadata
         self.sheet_view2 = NdMapping((None, im))
         self.sheet_view2.metadata = AttrDict(src_name='TestInputParam',
@@ -100,7 +100,7 @@ class TestPlot(unittest.TestCase):
         ### Find a way to assign randomly the matrix.
         self.matrix3 = np.zeros((10,10),dtype=np.float) + np.random.random((10,10))
         self.bounds3 = BoundingBox(points=((-0.5,-0.5),(0.5,0.5)))
-        im = Image(self.matrix3, self.bounds3)
+        im = Image(self.matrix3, bounds=self.bounds3)
         im.metadata=metadata
         self.sheet_view3 = NdMapping((None, im))
         self.sheet_view3.metadata = AttrDict(src_name='TestInputParam',
@@ -113,7 +113,7 @@ class TestPlot(unittest.TestCase):
         ### Find a way to assign randomly the matrix.
         self.matrix4 = np.zeros((10,10),dtype=np.float) + 1.6
         self.bounds4 = BoundingBox(points=((-0.7,-0.7),(0.7,0.7)))
-        im = Image(self.matrix4, self.bounds4)
+        im = Image(self.matrix4, bounds=self.bounds4)
         im.metadata=metadata
         self.sheet_view4 = NdMapping((None, im))
         self.sheet_view4.metadata = AttrDict(src_name='TestInputParam',

--- a/topo/tests/unit/testplot.py
+++ b/topo/tests/unit/testplot.py
@@ -16,7 +16,7 @@ import numpy as np
 import param
 
 from holoviews.core import BoundingBox, NdMapping
-from holoviews.interface.collector import AttrDict
+from topo.misc.attrdict import AttrDict
 from holoviews import Image
 
 

--- a/topo/tkgui/topoconsole.py
+++ b/topo/tkgui/topoconsole.py
@@ -531,7 +531,7 @@ class TopoConsole(tk.AppWindow,tk.TkParameterized):
             except:
                 pass
 
-            self.message("Quit selected%s" % ("; exiting" if  self.exit_on_quit else ""))
+#             self.message("Quit selected%s" % ("; exiting" if  self.exit_on_quit else "")) # Removed because does not restore prompt
 
             # Workaround for obscure problem on some UNIX systems
             # as of 4/2007, probably including Fedora Core 5.

--- a/topographica
+++ b/topographica
@@ -6,7 +6,7 @@
 try:    import external
 except: pass
 
-import  sys, topo
+import  sys
 
 if not (sys.version_info[0] == 2 and sys.version_info[1] == 7):
     print "Warning: Topographica requires Python 2.7, and will not currently work with any other version."


### PR DESCRIPTION
These changes allows topographica to run with the head version of holoviews. These requires my push request for featuremapper.
The one thing that that does not run correctly is the composition:
`CoG_spec = "Image.X CoG * Image.Y CoG * Image.BlueChannel"
XYCoG = chain.instance(group='XYCoG', name='XYCoG',
                       operations = [image_overlay.instance(spec=CoG_spec), factory.instance()])
Compositor.register(Compositor("Image.X CoG * Image.Y CoG", XYCoG, 'XYCoG', 'display'))
` 
defined in topo.analysis. As is, it causes an error when trying to display an overlay of CoGs.
If this is deleted overlays appear without an error. Any attempt that I made to fix this avoided the error, but only displayed outlines of the images.